### PR TITLE
Fix GUI launch button wiring

### DIFF
--- a/python_gui/app/main.py
+++ b/python_gui/app/main.py
@@ -1,6 +1,8 @@
-import subprocess, sys, os, tkinter as tk
-from core.runner import run_task
+import tkinter as tk
+
 import customtkinter as ctk
+
+from core.runner import run_task
 
 def append_to_textbox(s: str):
     txt.insert("end", s + "\n")
@@ -13,9 +15,6 @@ app.geometry("900x600")
 frame = ctk.CTkFrame(app)
 frame.pack(fill="x", padx=10, pady=10)
 
-btn = ctk.CTkButton(frame, text="Run Standard Build", command=run_task)
-btn.pack(side="left", padx=6)
-
 txt = tk.Text(app, wrap="word")
 txt.pack(fill="both", expand=True, padx=10, pady=(0,10))
 
@@ -25,5 +24,8 @@ def on_run_clicked():
         append_to_textbox("Elevated run started (output will appear in logs).")
     else:
         append_to_textbox(f"Task finished with exit code {code}")
+
+btn = ctk.CTkButton(frame, text="Run Standard Build", command=on_run_clicked)
+btn.pack(side="left", padx=6)
 
 app.mainloop()


### PR DESCRIPTION
## Summary
- wire the GUI button to call the standard build task helper with the required arguments
- remove unused imports from the GUI launcher entry point

## Testing
- pytest (passes, no tests discovered)
- Windows validation: not run (Linux container environment)


------
https://chatgpt.com/codex/tasks/task_e_68e6d779b5b883329a361ba2a16c2f30